### PR TITLE
JCodec is available on Maven Central.  No need to warn people about it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,6 @@ Video creation and manipulation in Clojure
 
 Currently you can use it to encode H264 video from a sequence of image frames. Not much support for anything else yet.
 
-## Note on JCodec usage
-
-Telegenic is a wrapper for the pure-Java JCodec library for video encoding / decoding. You may need to manually install the `jcodec-javase` dependency into your local maven repository, as this is currently not available on Maven Central. You can download the artifacts here:
-
-http://jcodec.org/
-
 ## Usage
 
 ```clojure


### PR DESCRIPTION
Running `lein deps` shows:

```
Retrieving net/mikera/telegenic/0.0.1/telegenic-0.0.1.pom from clojars
Retrieving net/mikera/imagez/0.9.0/imagez-0.9.0.pom from clojars
Retrieving org/jcodec/jcodec/0.1.9/jcodec-0.1.9.pom from central
Retrieving net/mikera/clojure-utils/0.5.0/clojure-utils-0.5.0.pom from clojars
Retrieving net/mikera/clojure-pom/0.0.4/clojure-pom-0.0.4.pom from clojars
Retrieving org/jcodec/jcodec-javase/0.1.9/jcodec-javase-0.1.9.pom from central
Retrieving org/jcodec/jcodec-javase/0.1.9/jcodec-javase-0.1.9.jar from central
Retrieving org/jcodec/jcodec/0.1.9/jcodec-0.1.9.jar from central
Retrieving net/mikera/clojure-utils/0.5.0/clojure-utils-0.5.0.jar from clojars
Retrieving net/mikera/telegenic/0.0.1/telegenic-0.0.1.jar from clojars
Retrieving net/mikera/imagez/0.9.0/imagez-0.9.0.jar from clojars
```

Which shows that JCodec can be fetched from Maven Central now.
